### PR TITLE
Prevent NullPointerException if  cordova.getActivity().getIntent() =null

### DIFF
--- a/src/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java
+++ b/src/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java
@@ -418,20 +418,20 @@ public class AppsFlyerPlugin extends CordovaPlugin {
 
     private boolean onResume(JSONArray parameters, CallbackContext callbackContext){
         Intent intent = cordova.getActivity().getIntent();
-        newIntentURI = intent.getData();
-
-        if (newIntentURI != intentURI) {
-            if (mAttributionData != null) {
-                PluginResult r = new PluginResult(PluginResult.Status.OK, mAttributionData.toString());
-                callbackContext.sendPluginResult(r);
-                mAttributionData = null;
-            } else {
-                mAttributionDataListener = callbackContext;
-                sendPluginNoResult(callbackContext);
-            }
-            
-            intentURI = newIntentURI;
-        }
+		if (intent != null) {
+			newIntentURI = intent.getData();
+			if (newIntentURI != intentURI) {
+				if (mAttributionData != null) {
+					PluginResult r = new PluginResult(PluginResult.Status.OK, mAttributionData.toString());
+					callbackContext.sendPluginResult(r);
+					mAttributionData = null;
+				} else {
+					mAttributionDataListener = callbackContext;
+					sendPluginNoResult(callbackContext);
+				}
+				intentURI = newIntentURI;
+			}
+		}
         return true;
     }
 


### PR DESCRIPTION
Prevent NullPointerException in cases when  `cordova.getActivity().getIntent() = null`