### PR TITLE
Fixed <source-file> tag for Android 7.1.0 + SDK version update

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+### 4.4.12
+Release date **Nov 14 2018**
+Release type: Major / Minor / **Hotfix**
+
+**Overview and Highlights:**
+
+- Fixed Android platform <source-file /> tag to work with Cordova-Android 7.1.0 and above
+
+- Updated Android SDK to v4.8.18
+
+- Updated iOS SDK to v4.8.10
+
 
 ### 4.4.10
 Release date: **Nov 01 2018**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appsflyer-sdk",
-  "version": "4.4.11",
+  "version": "4.4.12",
   "description": "Cordova AppsFlyer SDK Plugin",
   "cordova": {
     "id": "cordova-plugin-appsflyer-sdk",

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-appsflyer-sdk"
-        version="4.4.11">
+        version="4.4.12">
     <name>AppsFlyer</name>
     <description>Cordova Plugin AppsFlyer</description>
     <license>Apache 2.0</license>
@@ -61,8 +61,8 @@
             </receiver>
         </config-file>
 
-        <source-file src="src/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java" target-dir="app/src/main/java/com/appsflyer/cordova/plugin" />
-        <source-file src="src/android/com/appsflyer/cordova/plugin/AppsFlyerConstants.java" target-dir="app/src/main/java/com/appsflyer/cordova/plugin" />
+        <source-file src="src/android/com/appsflyer/cordova/plugin/AppsFlyerPlugin.java" target-dir="src/com/appsflyer/cordova/plugin" />
+        <source-file src="src/android/com/appsflyer/cordova/plugin/AppsFlyerConstants.java" target-dir="src/com/appsflyer/cordova/plugin" />
         
         <framework src="src/android/cordovaAF.gradle" custom="true" type="gradleReference" />
     </platform>

--- a/src/android/cordovaAF.gradle
+++ b/src/android/cordovaAF.gradle
@@ -4,6 +4,6 @@ repositories {
 
 dependencies {
 	compile 'com.android.installreferrer:installreferrer:1.0'
-	compile 'com.appsflyer:af-android-sdk:4.8.17@aar'
+	compile 'com.appsflyer:af-android-sdk:4.8.18@aar'
 
 }


### PR DESCRIPTION
- Fixed Android platform <source-file /> tag to work with Cordova-Android 7.1.0 and above

- Updated Android SDK to v4.8.18

- Updated iOS SDK to v4.8.10