### PR TITLE
DELIVERY-120039: Fix iOS strict mode UDL auth-failure

### DIFF
--- a/src/ios/AppsFlyerPlugin.m
+++ b/src/ios/AppsFlyerPlugin.m
@@ -91,16 +91,16 @@ static NSString *const NO_WAITING_TIME = @"You need to set waiting time for ATT"
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
         return;
     } else {
-        if (isDeepLinking == YES) {
-            [AppsFlyerLib shared].deepLinkDelegate = self;
-        }
-
-        // Initialize the SDK
+        // Set credentials before deepLinkDelegate (UDL can fire a server request immediately).
         [[AppsFlyerLib shared] setPluginInfoWith:AFSDKPluginCordova pluginVersion:@"6.18.0" additionalParams:nil];
         [AppsFlyerLib shared].appleAppID = appId;
         [AppsFlyerLib shared].appsFlyerDevKey = devKey;
         [AppsFlyerLib shared].isDebug = isDebug;
         [AppsFlyerLib shared].useUninstallSandbox = useUninstallSandbox;
+
+        if (isDeepLinking == YES) {
+            [AppsFlyerLib shared].deepLinkDelegate = self;
+        }
     }
 
 #ifndef AFSDK_NO_IDFA


### PR DESCRIPTION
## Summary
- Reorder iOS `initSdk` so `appleAppID`, `appsFlyerDevKey`, and related SDK config are set **before** `deepLinkDelegate`.
- Fixes deferred deep linking failures (`auth-failure` / HTTP 400) when using iOS strict mode with UDL enabled.
- Mirrors the Flutter fix shipped in [DELIVERY-106333](https://appsflyer.atlassian.net/browse/DELIVERY-106333) (`cc9c19b`).
- Android unchanged — `subscribeForDeepLink()` only registers a passive listener and does not trigger server requests.

## Test plan
- [ ] iOS strict mode: fresh install deferred deep link → UDL callback returns expected result (no `auth-failure` in `dl_data`)
- [ ] iOS non-strict: UDL still works for direct and deferred deep links
- [ ] Regression: `onInstallConversionData` and manual start (`shouldStartSdk: false`) unchanged
- [ ] Run iOS E2E phases covering `onDeepLinking` if available in CI


Made with [Cursor](https://cursor.com)