### PR TITLE
DELIVERY-120039: Fix iOS strict mode UDL auth-failure (RPC / Swift)

### DIFF
--- a/src/ios/AppsFlyerPlugin.swift
+++ b/src/ios/AppsFlyerPlugin.swift
@@ -50,6 +50,10 @@ public class AppsFlyerPlugin: CDVPlugin {
     /// After JS invokes RPC `start` once, `UIApplication.didBecomeActive` re-posts fire-and-forget `start` (replaces Obj-C `shouldStartSdk` / `sendLaunch:`).
     private var shouldStartSdk = false
 
+    /// `init` RPC must complete before `registerDeeplinkListener` (UDL can auth-fail in iOS strict mode otherwise).
+    private var initRpcCompleted = false
+    private var pendingRegisterDeeplinkListenerRpc = false
+
     /// Ensures we only register `NotificationCenter` observers once per plugin instance.
     private var didRegisterNotificationObservers = false
 
@@ -130,6 +134,16 @@ public class AppsFlyerPlugin: CDVPlugin {
                 shouldStartSdk = true
             }
 
+            if rpcMethod == "registerDeeplinkListener", !initRpcCompleted {
+                pendingRegisterDeeplinkListenerRpc = true
+                logRpc("executeRpc: deferring registerDeeplinkListener until init RPC succeeds")
+                sendRegistrationAck(command: command) { [weak self] result in
+                    guard let self = self, let result = result else { return }
+                    self.commandDelegate.send(result, callbackId: command.callbackId)
+                }
+                return
+            }
+
             let requestJson: String
             do {
                 requestJson = try Self.buildJsonRpcEnvelope(method: rpcMethod, params: rpcParams)
@@ -143,6 +157,11 @@ public class AppsFlyerPlugin: CDVPlugin {
 
             let responseJson = await rpcClient.execute(jsonRequest: requestJson)
             logRpc("executeRpc: response \(Self.truncateForLog(responseJson))")
+
+            if rpcMethod == "init", Self.isRpcResponseSuccess(responseJson) {
+                initRpcCompleted = true
+                await flushPendingRegisterDeeplinkListenerRpcIfNeeded()
+            }
 
             Self.sendRpcEnvelopeToCordova(
                 responseJson,
@@ -421,6 +440,7 @@ public class AppsFlyerPlugin: CDVPlugin {
             logRpc("registration: deep link listener → callbackId=\(cb ?? "nil")")
         case "unsubscribeForDeepLink":
             deepLinkListenerCallbackId = nil
+            pendingRegisterDeeplinkListenerRpc = false
             logRpc("registration: deep link listener cleared")
         case "registerConversionListener":
             conversionListenerCallbackId = cb
@@ -437,6 +457,37 @@ public class AppsFlyerPlugin: CDVPlugin {
         let result = CDVPluginResult(status: CDVCommandStatus.noResult)
         result.keepCallback = true
         send(result)
+    }
+
+    /// Runs deferred `registerDeeplinkListener` after successful `init` (mirrors Obj-C credential-before-delegate ordering).
+    private func flushPendingRegisterDeeplinkListenerRpcIfNeeded() async {
+        guard pendingRegisterDeeplinkListenerRpc else { return }
+        pendingRegisterDeeplinkListenerRpc = false
+        do {
+            let json = try Self.buildJsonRpcEnvelope(method: "registerDeeplinkListener", params: [:])
+            logRpc("flushPendingRegisterDeeplinkListener: \(Self.truncateForLog(json))")
+            _ = await rpcClient.execute(jsonRequest: json)
+        } catch {
+            logRpc("flushPendingRegisterDeeplinkListener: failed — \(error.localizedDescription)")
+        }
+    }
+
+    /// `true` when the RPC envelope has no transport/handler error (same rules as `sendRpcEnvelopeToCordova`).
+    private static func isRpcResponseSuccess(_ responseJson: String) -> Bool {
+        guard let data = responseJson.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return false
+        }
+        if let transportError = obj["error"] as? [String: Any], !transportError.isEmpty {
+            return false
+        }
+        if let dict = obj["result"] as? [String: Any],
+           let success = dict["success"] as? Bool,
+           success == false {
+            return false
+        }
+        return true
     }
 
     /// Maps AFRPC JSON to Cordova (aligned with iOS `result.success` convention).


### PR DESCRIPTION
## Summary
- On the RPC/Swift iOS path, defer `registerDeeplinkListener` until after a successful `init` RPC.
- `subscribeForDeepLink` / `registerDeepLink` may be called before `initSdk` (see `examples/cordovatestapp`); firing the deeplink listener RPC before credentials are set causes the same UDL `auth-failure` / 400 seen in [DELIVERY-120039](https://appsflyer.atlassian.net/browse/DELIVERY-120039).
- Mirrors the Obj-C init-order fix on `development` ([#303](https://github.com/AppsFlyerSDK/appsflyer-cordova-plugin/pull/303)), adapted for the RPC architecture.
- Android unchanged.

## Implementation
- Track `initRpcCompleted` and `pendingRegisterDeeplinkListenerRpc` in `AppsFlyerPlugin.swift`.
- If `registerDeeplinkListener` arrives before `init` succeeds: store Cordova callback, ack to JS, flush RPC after successful `init`.
- Clear pending state on `unsubscribeForDeepLink`.

## Test plan
- [ ] iOS strict mode: `registerDeepLink` before `initSdk` → deferred listener still receives UDL (no auth-failure)
- [ ] `registerDeepLink` after `initSdk` → unchanged behavior
- [ ] `unsubscribeForDeepLink` before `init` clears pending registration
- [ ] Regression: conversion listener, `start` RPC, foreground re-start


Made with [Cursor](https://cursor.com)